### PR TITLE
feat: pass through anthropic `disable_parallel_tool_use` setting when present

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -399,14 +399,24 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   end
 
   defp get_tool_choice(%ChatAnthropic{
-         tool_choice: %{"type" => "tool", "name" => name} = _tool_choice
+         tool_choice: %{"type" => "tool", "name" => name} = tool_choice
        })
-       when is_binary(name) and byte_size(name) > 0,
-       do: %{"type" => "tool", "name" => name}
+       when is_binary(name) and byte_size(name) > 0 do
+    %{"type" => "tool", "name" => name}
+    |> Utils.conditionally_add_to_map(
+      "disable_parallel_tool_use",
+      Map.get(tool_choice, "disable_parallel_tool_use")
+    )
+  end
 
-  defp get_tool_choice(%ChatAnthropic{tool_choice: %{"type" => type} = _tool_choice})
-       when is_binary(type) and byte_size(type) > 0,
-       do: %{"type" => type}
+  defp get_tool_choice(%ChatAnthropic{tool_choice: %{"type" => type} = tool_choice})
+       when is_binary(type) and byte_size(type) > 0 do
+    %{"type" => type}
+    |> Utils.conditionally_add_to_map(
+      "disable_parallel_tool_use",
+      Map.get(tool_choice, "disable_parallel_tool_use")
+    )
+  end
 
   defp get_tool_choice(%ChatAnthropic{}), do: nil
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -238,6 +238,30 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
       assert data.tool_choice == %{"type" => "tool", "name" => "get_weather"}
     end
 
+    test "includes disable_parallel_tool_use when set in tool_choice" do
+      {:ok, anthropic} =
+        ChatAnthropic.new(%{
+          model: @test_model,
+          tool_choice: %{"type" => "auto", "disable_parallel_tool_use" => true}
+        })
+
+      data = ChatAnthropic.for_api(anthropic, [], [])
+      assert data.model == @test_model
+      assert data.tool_choice == %{"type" => "auto", "disable_parallel_tool_use" => true}
+    end
+
+    test "includes disable_parallel_tool_use with specific tool" do
+      {:ok, anthropic} =
+        ChatAnthropic.new(%{
+          model: @test_model,
+          tool_choice: %{"type" => "tool", "name" => "get_weather", "disable_parallel_tool_use" => true}
+        })
+
+      data = ChatAnthropic.for_api(anthropic, [], [])
+      assert data.model == @test_model
+      assert data.tool_choice == %{"type" => "tool", "name" => "get_weather", "disable_parallel_tool_use" => true}
+    end
+
     test "adds tool definitions to map" do
       tool =
         Function.new!(%{


### PR DESCRIPTION
Anthropic has a `disable_parallel_tool_use` setting on the `tool_choice` object. This PR updates langchain to pass that setting through to the API call when present.

The parallel tool use setting allows the model to request multiple tool calls at once. We don't have an immediate use case for this, although it'd be useful in the future. The reason I'm disabling it now is because it'd make state aggregation slightly more complex in our system and I don't want to take on that complexity right now.

Looking for a review from the platform team before I open a PR against upstream.

I've tested this change in our application and confirmed it worked.